### PR TITLE
支付宝主页做了修改，所以将str.search("search_button")改为str.search("search")

### DIFF
--- a/alipay_auto.js
+++ b/alipay_auto.js
@@ -289,13 +289,14 @@ function clickByTextDesc(energyType,paddingY){
             //toastLog(pos.id());
             var str = pos.id();
             if(str != null){
-                if(str.search("search_button") == -1){
+                if(str.search("search") == -1){
                     click(posb.centerX(),posb.centerY()-paddingY);
                      //toastLog("get it 1");
                      clicked = true;   
                 }
             }else{
                 click(posb.centerX(),posb.centerY()-paddingY);
+                //toastLog("get it 2");
                 clicked = true;
             }
             sleep(100);
@@ -311,13 +312,14 @@ function clickByTextDesc(energyType,paddingY){
             //toastLog(pos.id());
             var str = pos.id();
             if(str != null){
-                if(str.search("search_button") == -1){
+                if(str.search("search") == -1){
                     click(posb.centerX(),posb.centerY()-paddingY); 
-                    //toastLog("get it 2"); 
+                    //toastLog("get it 3"); 
                     clicked = true;  
                 }
             }else{
                 click(posb.centerX(),posb.centerY()-paddingY);
+                //toastLog("get it 4");
                 clicked = true;
             }
             sleep(100);


### PR DESCRIPTION
支付宝主页的搜索栏会循环显示“准备金”，“蚂蚁借呗”，“蚂蚁森林”等等文字，最近该搜索栏的ID发生了变化，所以之前判断ID包含"search_button"就不对了，现在判断ID包含"search"即认为此ID为搜索栏